### PR TITLE
Use a wrapper type for remotes

### DIFF
--- a/src/ci/buildbot.rs
+++ b/src/ci/buildbot.rs
@@ -142,7 +142,8 @@ impl Worker {
             return;
         }
         *res.status_mut() = StatusCode::Ok;
-        res.headers_mut().set_raw("Content-Type", vec![b"text/plain".to_vec()]);
+        res.headers_mut()
+            .set_raw("Content-Type", vec![b"text/plain".to_vec()]);
         let result = res.send(&[]);
         if let Err(e) = result {
             warn!("Failed to send response: {:?}", e);
@@ -157,22 +158,32 @@ impl Worker {
                     Ok(builder) => {
                         if let Some(text) = builder.text {
                             if text.len() < 2 {
-                                warn!("Build {} incomplete, but has text", name);
+                                warn!(
+                                    "Build {} incomplete, but has text",
+                                    name
+                                );
                                 return;
                             }
                             info!("Builder {} complete", name);
-                            is_success = is_success && text.contains(&"successful".to_string());
+                            is_success = is_success &&
+                                text.contains(&"successful".to_string());
                             if let Some(ref revision) = revision {
-                                if revision != &builder.source_stamps[0].revision[..] {
+                                let b = &builder.source_stamps[0].revision[..];
+                                if revision != b {
                                     warn!(
-                                        "builders disagree on revision: {} and {}",
+                                        "builders different revs: {} and {}",
                                         revision,
                                         &builder.source_stamps[0].revision[..]
                                     );
                                     return;
                                 }
                             } else {
-                                revision = Some(builder.source_stamps[0].revision.clone());
+                                revision = Some(
+                                    builder
+                                    .source_stamps[0]
+                                    .revision
+                                    .clone()
+                                );
                             }
                         } else {
                             info!("Builder {} incomplete", name);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,49 +7,48 @@ pub mod sqlite;
 
 use ui::Pr;
 use pipeline::PipelineId;
-use vcs::Commit;
 
 /// A build queue
-pub trait Db<C: Commit, P: Pr> {
-    fn push_queue(&mut self, PipelineId, QueueEntry<C, P>);
-    fn pop_queue(&mut self, PipelineId) -> Option<QueueEntry<C, P>>;
-    fn list_queue(&mut self, PipelineId) -> Vec<QueueEntry<C, P>>;
-    fn put_running(&mut self, PipelineId, RunningEntry<C, P>);
-    fn take_running(&mut self, PipelineId) -> Option<RunningEntry<C, P>>;
-    fn peek_running(&mut self, PipelineId) -> Option<RunningEntry<C, P>>;
-    fn add_pending(&mut self, PipelineId, PendingEntry<C, P>);
+pub trait Db<P: Pr> {
+    fn push_queue(&mut self, PipelineId, QueueEntry<P>);
+    fn pop_queue(&mut self, PipelineId) -> Option<QueueEntry<P>>;
+    fn list_queue(&mut self, PipelineId) -> Vec<QueueEntry<P>>;
+    fn put_running(&mut self, PipelineId, RunningEntry<P>);
+    fn take_running(&mut self, PipelineId) -> Option<RunningEntry<P>>;
+    fn peek_running(&mut self, PipelineId) -> Option<RunningEntry<P>>;
+    fn add_pending(&mut self, PipelineId, PendingEntry<P>);
     fn peek_pending_by_pr(&mut self, PipelineId, &P)
-        -> Option<PendingEntry<C, P>>;
+        -> Option<PendingEntry<P>>;
     fn take_pending_by_pr(&mut self, PipelineId, &P)
-        -> Option<PendingEntry<C, P>>;
-    fn list_pending(&mut self, PipelineId) -> Vec<PendingEntry<C, P>>;
+        -> Option<PendingEntry<P>>;
+    fn list_pending(&mut self, PipelineId) -> Vec<PendingEntry<P>>;
     fn cancel_by_pr(&mut self, PipelineId, &P);
     /// Cancel all queued and running entries in the given pipeline
     /// with the same PR number and a different commit number.
     /// Returns true if an actual cancel occurred.
-    fn cancel_by_pr_different_commit(&mut self, PipelineId, &P, &C) -> bool;
+    fn cancel_by_pr_different_commit(&mut self, PipelineId, &P, &P::C) -> bool;
 }
 
 /// An item not yet in the build queue
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PendingEntry<C: Commit, P: Pr> {
-    pub commit: C,
+pub struct PendingEntry<P: Pr> {
+    pub commit: P::C,
     pub pr: P,
 }
 
 /// An item in the build queue
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct QueueEntry<C: Commit, P: Pr> {
-    pub commit: C,
+pub struct QueueEntry<P: Pr> {
+    pub commit: P::C,
     pub pr: P,
     pub message: String,
 }
 
 /// An item in the build queue that is currently running
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RunningEntry<C: Commit, P: Pr> {
-    pub pull_commit: C,
-    pub merge_commit: Option<C>,
+pub struct RunningEntry<P: Pr> {
+    pub pull_commit: P::C,
+    pub merge_commit: Option<P::C>,
     pub pr: P,
     pub message: String,
     pub canceled: bool,

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 #[derive(Clone, Debug)]
 pub enum Message<C: Commit> {
-    MergeToStaging(PipelineId, C, String, String),
+    MergeToStaging(PipelineId, C, String, C::Remote),
     MoveStagingToMaster(PipelineId, C),
 }
 
@@ -24,7 +24,8 @@ pub enum Event<C: Commit> {
 /// A reviewable changeset
 pub trait Commit: Clone + Debug + Display + Eq + FromStr + Into<String> +
                   PartialEq + Send {
-    // This trait intentionally defines no methods of its own
+    type Remote: Clone + Debug + Display + Eq + FromStr + Into<String> +
+                 PartialEq + Send;
 }
 
 impl<C: Commit + 'static> GetPipelineId for Event<C> {


### PR DESCRIPTION
Also some code cleanup, like making the Commit a type parameter of Pr, so the number of type parameters is reduced significantly.