### PR TITLE
Allow Github status notifications to be our CI

### DIFF
--- a/config.toml.taskcluster-example
+++ b/config.toml.taskcluster-example
@@ -1,0 +1,122 @@
+# This file is released under the same terms as Rust itself
+
+# Regular comments are written like this
+# Default options will be written with no space after the `#`
+# Others will not be commented out, and will have placeholders IN_ALL_CAPS
+
+[config]
+
+# Where to store the database
+#db = "db.sqlite"
+
+[config.view]
+listen = "localhost:8000"
+
+[config.github]
+
+# Port to listen for websockets
+listen = "localhost:6000"
+
+# User account to listen for commands on
+user = "aelita-mergebot"
+
+# Web address that the Github API is on; this is needed for Github Enterprise
+#host = "https://api.github.com"
+
+# Global default owner account for repositories
+# This is based on the observation that most organizations and individuals who
+# deploy aelita will own all their repos. It is not required to be specified
+# here, but if it is not specified it will need to be given for all projects
+owner = "MY_USER_OR_ORGANIZATON"
+
+# Personal access token; get it in the user account section on GitHub's website
+token = "MY_PERSONAL_ACCESS_TOKEN"
+
+# Jenkins configuration. Not required if you're not using jenkins
+[config.github.status]
+
+# Port to listen on for build-complete notifications
+# Yes, it needs to be different from the other Github notifications
+listen = "localhost:7000"
+
+# The git configuration section is not required, because all options have
+# defaults
+#[config.git]
+
+# Location of the `git` binary
+#executable = "git"
+
+# Base directory for all git checkouts
+#path = "./cache/"
+
+# Git committer name for the merge commit
+# Defaults to the Github username
+#name = "aelita-mergebot"
+
+# Git committer email for the merge commit
+# Defaults to the Github username @github.com
+#email = "aelita-mergebot@github.com"
+
+# This is a project definition
+# The part after the dot is the project's name
+[projects.MY_PROJECT]
+
+# Enable try support. Disabled by default.
+# try = {}
+
+# AS A NOTE: People used to homu and bors may expect a list of reviewers in
+# this section.
+# There is not one here, because the Github frontend will determine permissions
+# using Github's API.
+# For individually-owned repos, any collaborator can act as a reviewer.
+# For organizationally-owned repos, any member of a team that has push enabled.
+# The type of repo owner is determined at startup,
+# and the list of push teams is refreshed when a team event is received.
+#
+# (This algorithm is the closest thing I could get to
+# "r+ is enabled if the merge button is enabled")
+
+# Here, we specify the status notification context that's needed
+# Obviously, here's the TaskCluster one
+# There are more options, below
+github = { status = "TaskCluster" }
+
+# The Git part is implied by Github, but if you're not using Github, you'll
+# need to specify that this is a Git project
+# This is all that is typically needed; the rest of the options are described
+# below
+#git = {}
+
+# These are the options that can be configured for Github. If you use it,
+# remove the `github = {}` part
+#[projects.MY_PROJECT.github]
+
+# The owner of the project
+#owner = "MY_OWNER_OR_ORGANIZATON"
+
+# The project's repo. It defaults to the project's name
+#repo = "MY_PROJECT"
+
+# TaskCluster Github status is our CI
+#status = "TaskCluster"
+
+# These are the options that can be configured for Git. If you use it,
+# remove the `git = {}` part
+#[projects.MY_PROJECT.git]
+
+# The place to download this project
+# WARNING: This is not looked up using the API, so it needs to be specified
+# every time for Github Enterprise users
+#origin = "git@github.com:MY_OWNER_OR_ORGANIZATON/MY_PROJECT"
+
+# The name of the master branch. Defaults to `master`
+#master_branch = "master"
+
+# The name of the staging branch. Defaults to `staging`
+# If you're used to using homu or bors, they call it `auto`
+#staging_branch = "staging"
+
+# The project's path, below the base directory above. Defaults to the project's
+# name.
+#path = "MY_PROJECT"
+

--- a/config.toml.travis-example
+++ b/config.toml.travis-example
@@ -1,0 +1,122 @@
+# This file is released under the same terms as Rust itself
+
+# Regular comments are written like this
+# Default options will be written with no space after the `#`
+# Others will not be commented out, and will have placeholders IN_ALL_CAPS
+
+[config]
+
+# Where to store the database
+#db = "db.sqlite"
+
+[config.view]
+listen = "localhost:8000"
+
+[config.github]
+
+# Port to listen for websockets
+listen = "localhost:6000"
+
+# User account to listen for commands on
+user = "aelita-mergebot"
+
+# Web address that the Github API is on; this is needed for Github Enterprise
+#host = "https://api.github.com"
+
+# Global default owner account for repositories
+# This is based on the observation that most organizations and individuals who
+# deploy aelita will own all their repos. It is not required to be specified
+# here, but if it is not specified it will need to be given for all projects
+owner = "MY_USER_OR_ORGANIZATON"
+
+# Personal access token; get it in the user account section on GitHub's website
+token = "MY_PERSONAL_ACCESS_TOKEN"
+
+# Jenkins configuration. Not required if you're not using jenkins
+[config.github.status]
+
+# Port to listen on for build-complete notifications
+# Yes, it needs to be different from the other Github notifications
+listen = "localhost:7000"
+
+# The git configuration section is not required, because all options have
+# defaults
+#[config.git]
+
+# Location of the `git` binary
+#executable = "git"
+
+# Base directory for all git checkouts
+#path = "./cache/"
+
+# Git committer name for the merge commit
+# Defaults to the Github username
+#name = "aelita-mergebot"
+
+# Git committer email for the merge commit
+# Defaults to the Github username @github.com
+#email = "aelita-mergebot@github.com"
+
+# This is a project definition
+# The part after the dot is the project's name
+[projects.MY_PROJECT]
+
+# Enable try support. Disabled by default.
+# try = {}
+
+# AS A NOTE: People used to homu and bors may expect a list of reviewers in
+# this section.
+# There is not one here, because the Github frontend will determine permissions
+# using Github's API.
+# For individually-owned repos, any collaborator can act as a reviewer.
+# For organizationally-owned repos, any member of a team that has push enabled.
+# The type of repo owner is determined at startup,
+# and the list of push teams is refreshed when a team event is received.
+#
+# (This algorithm is the closest thing I could get to
+# "r+ is enabled if the merge button is enabled")
+
+# Here, we specify the status notification context that's needed
+# Obviously, here's the Travis one
+# There are more options, below
+github = { status = "continuous-integration/travis-ci/push" }
+
+# The Git part is implied by Github, but if you're not using Github, you'll
+# need to specify that this is a Git project
+# This is all that is typically needed; the rest of the options are described
+# below
+#git = {}
+
+# These are the options that can be configured for Github. If you use it,
+# remove the `github = {}` part
+#[projects.MY_PROJECT.github]
+
+# The owner of the project
+#owner = "MY_OWNER_OR_ORGANIZATON"
+
+# The project's repo. It defaults to the project's name
+#repo = "MY_PROJECT"
+
+# Travis Github status is our CI
+#status = "continuous-integration/travis-ci/push"
+
+# These are the options that can be configured for Git. If you use it,
+# remove the `git = {}` part
+#[projects.MY_PROJECT.git]
+
+# The place to download this project
+# WARNING: This is not looked up using the API, so it needs to be specified
+# every time for Github Enterprise users
+#origin = "git@github.com:MY_OWNER_OR_ORGANIZATON/MY_PROJECT"
+
+# The name of the master branch. Defaults to `master`
+#master_branch = "master"
+
+# The name of the staging branch. Defaults to `staging`
+# If you're used to using homu or bors, they call it `auto`
+#staging_branch = "staging"
+
+# The project's path, below the base directory above. Defaults to the project's
+# name.
+#path = "MY_PROJECT"
+

--- a/src/ci/buildbot.rs
+++ b/src/ci/buildbot.rs
@@ -65,7 +65,7 @@ impl<C> pipeline::Worker<ci::Event<C>, ci::Message<C>> for Worker
     where C: 'static + Commit + Sync, C::Err: Debug
 {
     fn run(
-        &mut self,
+        &self,
         recv_msg: Receiver<ci::Message<C>>,
         mut send_event: Sender<ci::Event<C>>
     ) {

--- a/src/ci/github_status.rs
+++ b/src/ci/github_status.rs
@@ -1,0 +1,269 @@
+// This file is released under the same terms as Rust itself.
+
+use ci;
+use crossbeam;
+use hyper::Url;
+use hyper::buffer::BufReader;
+use hyper::header::Headers;
+use hyper::net::{HttpListener, NetworkListener, NetworkStream};
+use hyper::server::{Request, Response};
+use hyper::status::StatusCode;
+use pipeline::{self, PipelineId};
+use serde_json::{from_reader as json_from_reader};
+use std::collections::HashMap;
+use std::io::BufWriter;
+use std::str::FromStr;
+use std::sync::mpsc::{Sender, Receiver};
+use vcs::git::Commit;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Repo {
+    pub owner: String,
+    pub repo: String,
+}
+
+#[derive(Debug)]
+struct RepoConfig {
+    pipeline_id: PipelineId,
+    context: String,
+}
+
+pub struct Worker {
+    listen: String,
+    pipelines: HashMap<Repo, Vec<RepoConfig>>,
+}
+
+impl Worker {
+    pub fn new(
+        listen: String,
+    ) -> Worker {
+        Worker {
+            listen: listen,
+            pipelines: HashMap::new(),
+        }
+    }
+    pub fn add_pipeline(
+        &mut self,
+        pipeline_id: PipelineId,
+        repo: Repo,
+        context: String,
+    ) {
+        let repo_config = RepoConfig{
+            pipeline_id: pipeline_id,
+            context: context,
+        };
+        self.pipelines.entry(repo)
+            .or_insert(Vec::new())
+            .push(repo_config);
+    }
+}
+
+// JSON API structs
+#[derive(Serialize, Deserialize)]
+struct PingDesc {
+    zen: String,
+}
+#[derive(Deserialize, Serialize)]
+struct StatusDesc {
+    state: String,
+    target_url: Option<String>,
+    context: String,
+    sha: String,
+    repository: RepositoryDesc,
+}
+#[derive(Serialize, Deserialize)]
+struct RepositoryDesc {
+    name: String,
+    owner: OwnerDesc,
+}
+#[derive(Serialize, Deserialize)]
+struct OwnerDesc {
+    login: String,
+}
+
+impl pipeline::Worker<
+    ci::Event<Commit>,
+    ci::Message<Commit>,
+> for Worker {
+    fn run(
+        &self,
+        recv_msg: Receiver<ci::Message<Commit>>,
+        mut send_event: Sender<ci::Event<Commit>>
+    ) {
+        crossbeam::scope(|scope| {
+            let s2 = &*self;
+            let send_event_2 = send_event.clone();
+            scope.spawn(move || {
+                s2.run_webhook(send_event_2);
+            });
+            loop {
+                s2.handle_message(
+                    recv_msg.recv().expect("Pipeline went away"),
+                    &mut send_event,
+                );
+            }
+        })
+    }
+}
+
+impl Worker {
+    fn run_webhook(
+        &self,
+        send_event: Sender<ci::Event<Commit>>,
+    ) {
+        let mut listener = HttpListener::new(&self.listen[..])
+            .expect("webhook");
+        while let Ok(mut stream) = listener.accept() {
+            let addr = stream.peer_addr()
+                .expect("webhook client address");
+            let mut stream_clone = stream.clone();
+            let mut buf_read = BufReader::new(
+                &mut stream_clone as &mut NetworkStream
+            );
+            let mut buf_write = BufWriter::new(&mut stream);
+            let req = match Request::new(&mut buf_read, addr) {
+                Ok(req) => req,
+                Err(e) => {
+                    warn!("Invalid webhook HTTP: {:?}", e);
+                    continue;
+                }
+            };
+            let mut head = Headers::new();
+            let res = Response::new(&mut buf_write, &mut head);
+            self.handle_webhook(req, res, &send_event);
+        }
+    }
+
+    fn handle_webhook(
+        &self,
+        req: Request,
+        mut res: Response,
+        send_event: &Sender<ci::Event<Commit>>
+    ) {
+        let x_github_event = {
+            if let Some(xges) = req.headers.get_raw("X-Github-Event") {
+                if let Some(xge) = xges.get(0) {
+                    xge.clone()
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            }
+        };
+        match &x_github_event[..] {
+            b"status" => {
+                if let Ok(desc) = json_from_reader::<_, StatusDesc>(req) {
+                    *res.status_mut() = StatusCode::NoContent;
+                    if let Err(e) = res.send(&[]) {
+                        warn!(
+                            "Failed to send response to Github status: {:?}",
+                            e,
+                        );
+                    }
+                    let repo = Repo{
+                        repo: desc.repository.name,
+                        owner: desc.repository.owner.login,
+                    };
+                    if let Some(repo_configs) = self.pipelines.get(&repo) {
+                        for repo_config in repo_configs {
+                            let commit = match Commit::from_str(&desc.sha) {
+                                Ok(commit) => commit,
+                                Err(e) => {
+                                    warn!(
+                                        "Invalid commit {}: {:?}",
+                                        desc.sha,
+                                        e
+                                    );
+                                    return;
+                                }
+                            };
+                            if repo_config.context == desc.context {
+                                let event = match &desc.state[..] {
+                                    "pending" => ci::Event::BuildStarted(
+                                        repo_config.pipeline_id,
+                                        commit,
+                                        desc.target_url.as_ref().and_then(|u|
+                                            Url::parse(&u[..]).ok()
+                                        ),
+                                    ),
+                                    "failure" |
+                                    "error" => ci::Event::BuildFailed(
+                                        repo_config.pipeline_id,
+                                        commit,
+                                        desc.target_url.as_ref().and_then(|u|
+                                            Url::parse(&u[..]).ok()
+                                        ),
+                                    ),
+                                    "success" => ci::Event::BuildSucceeded(
+                                        repo_config.pipeline_id,
+                                        commit,
+                                        desc.target_url.as_ref().and_then(|u|
+                                            Url::parse(&u[..]).ok()
+                                        ),
+                                    ),
+                                    _ => {
+                                        warn!(
+                                            "Unknown status state: {}",
+                                            desc.state
+                                        );
+                                        return;
+                                    },
+                                };
+                                send_event.send(event).expect("pipeline");
+                            }
+                        }
+                    } else {
+                        warn!("Got status for unknown repo: {:?}", repo);
+                    }
+                } else {
+                    warn!("Got invalid status");
+                    *res.status_mut() = StatusCode::BadRequest;
+                    if let Err(e) = res.send(&[]) {
+                        warn!(
+                            "Failed to send response to bad status: {:?}",
+                            e,
+                        );
+                    }
+                }
+            }
+            b"ping" => {
+                if let Ok(desc) = json_from_reader::<_, PingDesc>(req) {
+                    info!("Got Ping: {}", desc.zen);
+                    *res.status_mut() = StatusCode::NoContent;
+                } else {
+                    warn!("Got invalid Ping");
+                    *res.status_mut() = StatusCode::BadRequest;
+                }
+                if let Err(e) = res.send(&[]) {
+                    warn!("Failed to send response to Github ping: {:?}", e);
+                }
+            }
+            e => {
+                *res.status_mut() = StatusCode::BadRequest;
+                if let Err(e) = res.send(&[]) {
+                    warn!(
+                        "Failed to send response to Github unknown: {:?}",
+                        e,
+                    );
+                }
+                warn!(
+                    "Got Unknown Event {}",
+                    String::from_utf8_lossy(&e)
+                );
+            }
+        }
+    }
+
+    fn handle_message(
+        &self,
+        msg: ci::Message<Commit>,
+        _: &mut Sender<ci::Event<Commit>>,
+    ) {
+        match msg {
+            // The build is triggered by Github itself on push.
+            // There's nothing to do.
+            ci::Message::StartBuild(_, _) => {}
+        }
+    }
+}

--- a/src/ci/jenkins.rs
+++ b/src/ci/jenkins.rs
@@ -51,7 +51,7 @@ impl<C> pipeline::Worker<ci::Event<C>, ci::Message<C>> for Worker
     where C: 'static + Commit + Sync
 {
     fn run(
-        &mut self,
+        &self,
         recv_msg: Receiver<ci::Message<C>>,
         mut send_event: Sender<ci::Event<C>>
     ) {

--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -1,6 +1,7 @@
 // This file is released under the same terms as Rust itself.
 
 pub mod buildbot;
+pub mod github_status;
 pub mod jenkins;
 
 use hyper::Url;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -9,7 +9,7 @@ use ui::{self, Pr};
 use vcs::{self, Commit};
 
 pub trait Worker<E: Send + Clone, M: Send + Clone> {
-    fn run(&mut self, recv_msg: Receiver<M>, send_event: Sender<E>);
+    fn run(&self, recv_msg: Receiver<M>, send_event: Sender<E>);
 }
 
 pub struct WorkerThread<E: Send + Clone + 'static, M: Send + Clone + 'static> {
@@ -18,7 +18,7 @@ pub struct WorkerThread<E: Send + Clone + 'static, M: Send + Clone + 'static> {
 }
 
 impl<E: Send + Clone + 'static, M: Send + Clone + 'static> WorkerThread<E, M> {
-    pub fn start<T: Worker<E, M> + Send + 'static>(mut worker: T) -> Self {
+    pub fn start<T: Worker<E, M> + Send + 'static>(worker: T) -> Self {
         let (send_msg, recv_msg) = channel();
         let (send_event, recv_event) = channel();
         thread::spawn(move || {

--- a/src/ui/github.rs
+++ b/src/ui/github.rs
@@ -190,17 +190,12 @@ struct TeamAddDesc {
     repository: RepositoryDesc,
 }
 
-enum AcceptType {
-    Regular,
-    Repository,
-}
-
 impl pipeline::Worker<
     ui::Event<Pr>,
     ui::Message<Pr>,
 > for Worker {
     fn run(
-        &mut self,
+        &self,
         recv_msg: Receiver<ui::Message<Pr>>,
         mut send_event: Sender<ui::Event<Pr>>
     ) {
@@ -1001,6 +996,11 @@ impl Worker {
         self.client.request(method, url)
             .headers(headers)
     }
+}
+
+enum AcceptType {
+    Regular,
+    Repository,
 }
 
 quick_error! {

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -51,7 +51,7 @@ impl Worker {
 
 impl pipeline::Worker<vcs::Event<Commit>, vcs::Message<Commit>> for Worker {
     fn run(
-        &mut self,
+        &self,
         recv_msg: Receiver<vcs::Message<Commit>>,
         mut send_event: Sender<vcs::Event<Commit>>
     ) {

--- a/tests/test-github-round-trip-status.toml
+++ b/tests/test-github-round-trip-status.toml
@@ -1,0 +1,18 @@
+# This file is released under the same terms as Rust itself
+
+[config]
+
+[config.github]
+listen = "localhost:9001"
+host = "http://localhost:9011"
+user = "AelitaBot"
+owner = "AelitaBot"
+token = "MY_PERSONAL_ACCESS_TOKEN"
+
+[config.github.status]
+listen = "localhost:9002"
+
+[projects.testp]
+github = { status = "ci/test" }
+git = { origin = "../origin/" }
+


### PR DESCRIPTION
This will allow Travis CI and TaskCluster/Github to act as our CIs, by
reporting their status on the merge commits.

- Fixes #30 
