### PR TITLE
Do not crash when database connections drop

### DIFF
--- a/infra/aelita.yaml
+++ b/infra/aelita.yaml
@@ -327,7 +327,8 @@ spec:
               path: /
               port: 80
               httpHeaders:
-                - Host: "aelitabot.xyz"
+                - name: Host
+                  value: "aelitabot.xyz"
             initialDelaySeconds: 30
             timeoutSeconds: 2
 

--- a/src/config/twelvef.rs
+++ b/src/config/twelvef.rs
@@ -807,7 +807,9 @@ mod postgres {
                     WHERE owner = $1 AND repo = $2
                 "###;
                 let stmt = retry_unwrap!(conn.prepare(&sql));
-                let rows = retry_unwrap!(stmt.query(&[&repo.owner, &repo.repo]));
+                let rows = retry_unwrap!(
+                    stmt.query(&[&repo.owner, &repo.repo])
+                );
                 let rows = rows.iter();
                 let mut rows = rows.map(|row| {
                     github::RepoPipelines{
@@ -831,7 +833,9 @@ mod postgres {
                     WHERE pipeline_id = $1 OR try_pipeline_id = $2
                 "###;
                 let stmt = retry_unwrap!(conn.prepare(&sql));
-                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0, &pipeline_id.0]));
+                let rows = retry_unwrap!(stmt.query(
+                    &[&pipeline_id.0, &pipeline_id.0]
+                ));
                 let rows = rows.iter();
                 let mut rows = rows.map(|row| {
                     let pipeline_type =
@@ -985,7 +989,9 @@ mod postgres {
                     WHERE owner = $1 AND repo = $2 AND context = $3
                 "###;
                 let stmt = retry_unwrap!(conn.prepare(&sql));
-                let rows = retry_unwrap!(stmt.query(&[&repo.owner, &repo.repo, &repo.context]));
+                let rows = retry_unwrap!(
+                    stmt.query(&[&repo.owner, &repo.repo, &repo.context])
+                );
                 let rows = rows.iter();
                 let rows = rows.map(|row| {
                     PipelineId(row.get::<_, i32>(0))

--- a/src/config/twelvef.rs
+++ b/src/config/twelvef.rs
@@ -714,7 +714,7 @@ mod sqlite {
 mod postgres {
     use config::PipelineConfig as TPipelineConfig;
     use pipeline::PipelineId;
-    use postgres::{Connection, IntoConnectParams, SslMode};
+    use postgres::{Connection, ConnectParams, IntoConnectParams, SslMode};
     use std::borrow::Cow;
     use std::error::Error;
     use std::sync::Mutex;
@@ -728,23 +728,26 @@ mod postgres {
     use vcs::github::PipelinesConfig as TGithubGitPipelinesConfig;
     use view::{PipelinesConfig as TViewPipelinesConfig};
     pub struct PipelineConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl PipelineConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = PipelineConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_config_pipeline (
                     pipeline_id SERIAL PRIMARY KEY,
                     name TEXT,
                     UNIQUE (name)
                 );
             "###));
-            Ok(PipelineConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TPipelineConfig for PipelineConfig {
@@ -752,31 +755,33 @@ mod postgres {
             (0, 0, 0)
         }
         fn len(&self) -> usize {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT COUNT(*)
-                FROM twelvef_config_pipeline
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare pipeline count query");
-            let rows = stmt.query(&[]);
-            let rows = rows.expect("Get pipeline count");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                row.get::<_, i64>(0) as usize
-            });
-            rows.next().unwrap()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT COUNT(*)
+                    FROM twelvef_config_pipeline
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    row.get::<_, i64>(0) as usize
+                });
+                rows.next().unwrap()
+            }}
         }
     }
     pub struct GithubProjectsConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl GithubProjectsConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = GithubProjectsConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_github_projects (
                     pipeline_id INTEGER PRIMARY KEY,
                     try_pipeline_id INTEGER NULL,
@@ -785,145 +790,151 @@ mod postgres {
                     UNIQUE (owner, repo)
                 );
             "###));
-            Ok(GithubProjectsConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TGithubProjectsConfig for GithubProjectsConfig {
         fn pipelines_by_repo(&self, repo: &github::Repo)
                 -> Option<github::RepoPipelines>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT pipeline_id, try_pipeline_id
-                FROM twelvef_github_projects
-                WHERE owner = $1 AND repo = $2
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare pipelines query");
-            let rows = stmt.query(&[&repo.owner, &repo.repo]);
-            let rows = rows.expect("Get pipelines");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                github::RepoPipelines{
-                    pipeline_id:
-                        PipelineId(row.get::<_, i32>(0)),
-                    try_pipeline_id:
-                        row.get::<_, Option<i32>>(1).map(PipelineId),
-                }
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT pipeline_id, try_pipeline_id
+                    FROM twelvef_github_projects
+                    WHERE owner = $1 AND repo = $2
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&repo.owner, &repo.repo]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    github::RepoPipelines{
+                        pipeline_id:
+                            PipelineId(row.get::<_, i32>(0)),
+                        try_pipeline_id:
+                            row.get::<_, Option<i32>>(1).map(PipelineId),
+                    }
+                });
+                rows.next()
+            }}
         }
         fn repo_by_pipeline(&self, pipeline_id: PipelineId)
                 -> Option<(github::Repo, github::PipelineType)>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT owner, repo, pipeline_id
-                FROM twelvef_github_projects
-                WHERE pipeline_id = $1 OR try_pipeline_id = $2
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&pipeline_id.0, &pipeline_id.0]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                let pipeline_type =
-                    if row.get::<_, i32>(2) == pipeline_id.0 {
-                        github::PipelineType::Stage
-                    } else {
-                        github::PipelineType::Try
-                    };
-                (
-                    github::Repo{
-                        owner:
-                            row.get::<_, String>(0),
-                        repo:
-                            row.get::<_, String>(1),
-                    },
-                    pipeline_type
-                )
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT owner, repo, pipeline_id
+                    FROM twelvef_github_projects
+                    WHERE pipeline_id = $1 OR try_pipeline_id = $2
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0, &pipeline_id.0]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    let pipeline_type =
+                        if row.get::<_, i32>(2) == pipeline_id.0 {
+                            github::PipelineType::Stage
+                        } else {
+                            github::PipelineType::Try
+                        };
+                    (
+                        github::Repo{
+                            owner:
+                                row.get::<_, String>(0),
+                            repo:
+                                row.get::<_, String>(1),
+                        },
+                        pipeline_type
+                    )
+                });
+                rows.next()
+            }}
         }
     }
     pub struct JenkinsPipelinesConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl JenkinsPipelinesConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = JenkinsPipelinesConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_jenkins_pipelines (
                     pipeline_id INTEGER PRIMARY KEY,
                     name TEXT,
                     token TEXT
                 );
             "###));
-            Ok(JenkinsPipelinesConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TJenkinsPipelinesConfig for JenkinsPipelinesConfig {
         fn job_by_pipeline(&self, pipeline_id: PipelineId)
                 -> Option<jenkins::Job>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT name, token
-                FROM twelvef_jenkins_pipelines
-                WHERE pipeline_id = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&pipeline_id.0]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                jenkins::Job{
-                    name:
-                        row.get::<_, String>(0),
-                    token:
-                        row.get::<_, String>(1),
-                }
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT name, token
+                    FROM twelvef_jenkins_pipelines
+                    WHERE pipeline_id = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    jenkins::Job{
+                        name:
+                            row.get::<_, String>(0),
+                        token:
+                            row.get::<_, String>(1),
+                    }
+                });
+                rows.next()
+            }}
         }
         fn pipelines_by_job_name(&self, job: &str)
                 -> Vec<PipelineId>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT pipeline_id
-                FROM twelvef_jenkins_pipelines
-                WHERE name = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&job]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let rows = rows.map(|row| {
-                PipelineId(row.get::<_, i32>(0))
-            });
-            let rows = rows.collect();
-            rows
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT pipeline_id
+                    FROM twelvef_jenkins_pipelines
+                    WHERE name = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&job]));
+                let rows = rows.iter();
+                let rows = rows.map(|row| {
+                    PipelineId(row.get::<_, i32>(0))
+                });
+                let rows = rows.collect();
+                rows
+            }}
         }
     }
     pub struct GithubStatusPipelinesConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl GithubStatusPipelinesConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = GithubStatusPipelinesConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_github_status_pipelines (
                     pipeline_id INTEGER PRIMARY KEY,
                     owner TEXT,
@@ -931,68 +942,71 @@ mod postgres {
                     context TEXT
                 );
             "###));
-            Ok(GithubStatusPipelinesConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TGithubStatusPipelinesConfig for GithubStatusPipelinesConfig {
         fn repo_by_pipeline(&self, pipeline_id: PipelineId)
                 -> Option<github_status::Repo>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT owner, repo, context
-                FROM twelvef_github_status_pipelines
-                WHERE pipeline_id = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&pipeline_id.0]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                github_status::Repo{
-                    owner:
-                        row.get::<_, String>(0),
-                    repo:
-                        row.get::<_, String>(1),
-                    context:
-                        row.get::<_, String>(2),
-                }
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT owner, repo, context
+                    FROM twelvef_github_status_pipelines
+                    WHERE pipeline_id = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    github_status::Repo{
+                        owner:
+                            row.get::<_, String>(0),
+                        repo:
+                            row.get::<_, String>(1),
+                        context:
+                            row.get::<_, String>(2),
+                    }
+                });
+                rows.next()
+            }}
         }
         fn pipelines_by_repo(&self, repo: &github_status::Repo)
                 -> Vec<PipelineId>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT pipeline_id
-                FROM twelvef_github_status_pipelines
-                WHERE owner = $1 AND repo = $2 AND context = $3
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&repo.owner, &repo.repo, &repo.context]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let rows = rows.map(|row| {
-                PipelineId(row.get::<_, i32>(0))
-            });
-            let rows = rows.collect();
-            rows
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT pipeline_id
+                    FROM twelvef_github_status_pipelines
+                    WHERE owner = $1 AND repo = $2 AND context = $3
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&repo.owner, &repo.repo, &repo.context]));
+                let rows = rows.iter();
+                let rows = rows.map(|row| {
+                    PipelineId(row.get::<_, i32>(0))
+                });
+                let rows = rows.collect();
+                rows
+            }}
         }
     }
     pub struct GithubGitPipelinesConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl GithubGitPipelinesConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = GithubGitPipelinesConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_github_git_pipelines (
                     pipeline_id INTEGER PRIMARY KEY,
                     owner TEXT,
@@ -1002,57 +1016,60 @@ mod postgres {
                     push_to_master BOOLEAN
                 );
             "###));
-            Ok(GithubGitPipelinesConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TGithubGitPipelinesConfig for GithubGitPipelinesConfig {
         fn repo_by_pipeline(&self, pipeline_id: PipelineId)
                 -> Option<github_git::Repo>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT
-                    owner,
-                    repo,
-                    master_branch,
-                    staging_branch,
-                    push_to_master
-                FROM twelvef_github_git_pipelines
-                WHERE pipeline_id = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&pipeline_id.0]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                github_git::Repo{
-                    owner:
-                        row.get::<_, String>(0),
-                    repo:
-                        row.get::<_, String>(1),
-                    master_branch:
-                        row.get::<_, String>(2),
-                    staging_branch:
-                        row.get::<_, String>(3),
-                    push_to_master:
-                        row.get::<_, bool>(4),
-                }
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT
+                        owner,
+                        repo,
+                        master_branch,
+                        staging_branch,
+                        push_to_master
+                    FROM twelvef_github_git_pipelines
+                    WHERE pipeline_id = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    github_git::Repo{
+                        owner:
+                            row.get::<_, String>(0),
+                        repo:
+                            row.get::<_, String>(1),
+                        master_branch:
+                            row.get::<_, String>(2),
+                        staging_branch:
+                            row.get::<_, String>(3),
+                        push_to_master:
+                            row.get::<_, bool>(4),
+                    }
+                });
+                rows.next()
+            }}
         }
     }
     pub struct GitPipelinesConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl GitPipelinesConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            try!(conn.batch_execute(r###"
+            let result = GitPipelinesConfig{
+                params: try!(params.into_connect_params()),
+            };
+            try!(try!(result.conn()).batch_execute(r###"
                 CREATE TABLE IF NOT EXISTS twelvef_git_pipelines (
                     pipeline_id INTEGER PRIMARY KEY,
                     path TEXT,
@@ -1062,100 +1079,104 @@ mod postgres {
                     push_to_master TEXT
                 );
             "###));
-            Ok(GitPipelinesConfig{
-                conn: Mutex::new(conn),
-            })
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TGitPipelinesConfig for GitPipelinesConfig {
         fn repo_by_pipeline(&self, pipeline_id: PipelineId)
                 -> Option<git::Repo>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT
-                    path,
-                    origin,
-                    master_branch,
-                    staging_branch,
-                    push_to_master
-                FROM twelvef_git_pipelines
-                WHERE pipeline_id = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&pipeline_id.0]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                git::Repo{
-                    path:
-                        row.get::<_, String>(0),
-                    origin:
-                        row.get::<_, String>(1),
-                    master_branch:
-                        row.get::<_, String>(2),
-                    staging_branch:
-                        row.get::<_, String>(3),
-                    push_to_master:
-                        row.get::<_, bool>(4),
-                }
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT
+                        path,
+                        origin,
+                        master_branch,
+                        staging_branch,
+                        push_to_master
+                    FROM twelvef_git_pipelines
+                    WHERE pipeline_id = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    git::Repo{
+                        path:
+                            row.get::<_, String>(0),
+                        origin:
+                            row.get::<_, String>(1),
+                        master_branch:
+                            row.get::<_, String>(2),
+                        staging_branch:
+                            row.get::<_, String>(3),
+                        push_to_master:
+                            row.get::<_, bool>(4),
+                    }
+                });
+                rows.next()
+            }}
         }
     }
     pub struct ViewPipelinesConfig {
-        conn: Mutex<Connection>,
+        params: ConnectParams,
     }
     impl ViewPipelinesConfig {
         pub fn new<Q: IntoConnectParams>(params: Q)
                 -> Result<Self, Box<Error + Send + Sync + 'static>>
         {
-            let conn = try!(Connection::connect(params, SslMode::None));
-            Ok(ViewPipelinesConfig{
-                conn: Mutex::new(conn),
-            })
+            let result = ViewPipelinesConfig{
+                params: try!(params.into_connect_params()),
+            };
+            Ok(result)
+        }
+        fn conn(&self) -> Result<Connection, Box<Error + Send + Sync>> {
+            Ok(try!(Connection::connect(self.params.clone(), SslMode::None)))
         }
     }
     impl TViewPipelinesConfig for ViewPipelinesConfig {
         fn pipeline_by_name(&self, name: &str)
                 -> Option<PipelineId>
         {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT pipeline_id
-                FROM twelvef_config_pipeline
-                WHERE name = $1
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[&name]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let mut rows = rows.map(|row| {
-                PipelineId(row.get::<_, i32>(0))
-            });
-            rows.next()
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT pipeline_id
+                    FROM twelvef_config_pipeline
+                    WHERE name = $1
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[&name]));
+                let rows = rows.iter();
+                let mut rows = rows.map(|row| {
+                    PipelineId(row.get::<_, i32>(0))
+                });
+                rows.next()
+            }}
         }
         fn all(&self) -> Vec<(Cow<str>, PipelineId)> {
-            let conn = self.conn.lock().unwrap();
-            let sql = r###"
-                SELECT name, pipeline_id
-                FROM twelvef_config_pipeline
-            "###;
-            let stmt = conn.prepare(&sql)
-                .expect("Prepare repo query");
-            let rows = stmt.query(&[]);
-            let rows = rows.expect("Get repos");
-            let rows = rows.iter();
-            let rows = rows.map(|row| {
-                (
-                    Cow::Owned(row.get::<_, String>(0)),
-                    PipelineId(row.get::<_, i32>(1)),
-                )
-            });
-            let rows = rows.collect();
-            rows
+            retry!{{
+                let conn = retry_unwrap!(self.conn());
+                let sql = r###"
+                    SELECT name, pipeline_id
+                    FROM twelvef_config_pipeline
+                "###;
+                let stmt = retry_unwrap!(conn.prepare(&sql));
+                let rows = retry_unwrap!(stmt.query(&[]));
+                let rows = rows.iter();
+                let rows = rows.map(|row| {
+                    (
+                        Cow::Owned(row.get::<_, String>(0)),
+                        PipelineId(row.get::<_, i32>(1)),
+                    )
+                });
+                let rows = rows.collect();
+                rows
+            }}
         }
     }
 }

--- a/src/config/twelvef.rs
+++ b/src/config/twelvef.rs
@@ -717,7 +717,6 @@ mod postgres {
     use postgres::{Connection, ConnectParams, IntoConnectParams, SslMode};
     use std::borrow::Cow;
     use std::error::Error;
-    use std::sync::Mutex;
     use ui::github::{self, ProjectsConfig as TGithubProjectsConfig};
     use ci::jenkins::{self, PipelinesConfig as TJenkinsPipelinesConfig};
     use ci::github_status;

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -61,103 +61,108 @@ impl<P> Db<P> for PostgresDb<P>
           <P::C as FromStr>::Err: ::std::error::Error,
           <P as FromStr>::Err: ::std::error::Error,
 {
-    fn transaction<T: db::Transaction<P>>(&mut self, t: T) {
+    fn transaction<T: db::Transaction<P>>(
+        &mut self,
+        t: T,
+    ) -> Result<(), Box<Error + Send + Sync>> {
         let mut transaction = PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         );
-        let result = t.run(&mut transaction);
-        if result {
-            transaction.conn.commit().expect("to commit successfully");
-        }
+        try!(t.run(&mut transaction));
+        try!(transaction.conn.commit());
+        Ok(())
     }
     fn push_queue(
         &mut self,
         pipeline_id: PipelineId,
-        queue_entry: QueueEntry<P>
-    ) {
+        queue_entry: QueueEntry<P>,
+    ) -> Result<(), Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).push_queue(pipeline_id, queue_entry)
     }
     fn pop_queue(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<QueueEntry<P>> {
+    ) -> Result<Option<QueueEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).pop_queue(pipeline_id)
     }
     fn list_queue(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Vec<QueueEntry<P>> {
+    ) -> Result<Vec<QueueEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).list_queue(pipeline_id)
     }
     fn put_running(
         &mut self,
         pipeline_id: PipelineId,
         running_entry: RunningEntry<P>
-    ) {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).put_running(pipeline_id, running_entry)
     }
     fn take_running(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<RunningEntry<P>> {
+    ) -> Result<Option<RunningEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).take_running(pipeline_id)
     }
     fn peek_running(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<RunningEntry<P>> {
+    ) -> Result<Option<RunningEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).peek_running(pipeline_id)
     }
     fn add_pending(
         &mut self,
         pipeline_id: PipelineId,
         entry: PendingEntry<P>,
-    ) {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).add_pending(pipeline_id, entry)
     }
     fn take_pending_by_pr(
         &mut self,
         pipeline_id: PipelineId,
         pr: &P,
-    ) -> Option<PendingEntry<P>> {
+    ) -> Result<Option<PendingEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).take_pending_by_pr(pipeline_id, pr)
     }
     fn peek_pending_by_pr(
         &mut self,
         pipeline_id: PipelineId,
         pr: &P,
-    ) -> Option<PendingEntry<P>> {
+    ) -> Result<Option<PendingEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).peek_pending_by_pr(pipeline_id, pr)
     }
     fn list_pending(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Vec<PendingEntry<P>> {
+    ) -> Result<Vec<PendingEntry<P>>, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).list_pending(pipeline_id)
     }
-    fn cancel_by_pr(&mut self, pipeline_id: PipelineId, pr: &P) {
+    fn cancel_by_pr(
+        &mut self,
+        pipeline_id: PipelineId, pr: &P
+    ) -> Result<(), Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).cancel_by_pr(pipeline_id, pr)
     }
     fn cancel_by_pr_different_commit(
@@ -165,9 +170,9 @@ impl<P> Db<P> for PostgresDb<P>
         pipeline_id: PipelineId,
         pr: &P,
         commit: &P::C,
-    ) -> bool {
+    ) -> Result<bool, Box<Error + Send + Sync>> {
         PostgresTransaction::new(
-            self.conn.transaction().expect("to open transaction")
+            try!(self.conn.transaction())
         ).cancel_by_pr_different_commit(pipeline_id, pr, commit)
     }
 }
@@ -200,25 +205,25 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
         &mut self,
         pipeline_id: PipelineId,
         QueueEntry{pr, commit, message}: QueueEntry<P>
-    ) {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         let sql = r###"
             INSERT INTO queue (pr, pipeline_id, pull_commit, message)
             VALUES ($1, $2, $3, $4)
         "###;
-        self.conn.execute(sql, &[
+        try!(self.conn.execute(sql, &[
             &pr.into(),
             &pipeline_id.0,
             &commit.into(),
             &message,
-        ]).expect("Push-to-queue");
+        ]));
+        Ok(())
     }
     fn pop_queue(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<QueueEntry<P>> {
-        let trans = self.conn
-            .transaction()
-            .expect("Start pop-from-queue transaction");
+    ) -> Result<Option<QueueEntry<P>>, Box<Error + Send + Sync>> {
+        let trans = try!(self.conn
+            .transaction());
         let sql = r###"
             SELECT id, pr, pull_commit, message
             FROM queue
@@ -226,8 +231,8 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             ORDER BY id ASC LIMIT 1
         "###;
         let item = {
-            let stmt = trans.prepare(sql).expect("Pop from queue");
-            let rows = stmt.query(&[&pipeline_id.0]).expect("pop from queue");
+            let stmt = try!(trans.prepare(sql));
+            let rows = try!(stmt.query(&[&pipeline_id.0]));
             let rows = rows.iter();
             let mut rows = rows.map(|row| (
                 row.get::<_, i32>(0),
@@ -243,25 +248,23 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             let sql = r###"
                 DELETE FROM queue WHERE id = $1
             "###;
-            trans.execute(sql, &[&id]).expect("Delete pop-from-queue row");
+            try!(trans.execute(sql, &[&id]));
         }
-        trans.commit().expect("Commit pop-from-queue transaction");
-        item.map(|item| item.1)
+        try!(trans.commit());
+        Ok(item.map(|item| item.1))
     }
     fn list_queue(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Vec<QueueEntry<P>> {
+    ) -> Result<Vec<QueueEntry<P>>, Box<Error + Send + Sync>> {
         let sql = r###"
             SELECT pr, pull_commit, message
             FROM queue
             WHERE pipeline_id = $1
             ORDER BY id ASC
         "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare list-queue query");
-        let rows = stmt.query(&[&pipeline_id.0])
-            .expect("Get queue entry");
+        let stmt = try!(self.conn.prepare(&sql));
+        let rows = try!(stmt.query(&[&pipeline_id.0]));
         let rows = rows.iter();
         let rows = rows.map(|row| QueueEntry {
             pr: P::from_str(&row.get::<_, String>(0)).unwrap(),
@@ -269,7 +272,7 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             message: row.get::<_, String>(2),
         });
         let rows: Vec<QueueEntry<P>> = rows.collect();
-        rows
+        Ok(rows)
     }
     fn put_running(
         &mut self,
@@ -282,7 +285,7 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             canceled,
             built,
         }: RunningEntry<P>
-    ) {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         let sql = r###"
             INSERT INTO running
                 (
@@ -304,7 +307,7 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
                 canceled = $6,
                 built = $7
         "###;
-        self.conn.execute(sql, &[
+        try!(self.conn.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr),
             &<P::C as Into<String>>::into(pull_commit),
@@ -312,24 +315,22 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             &message,
             &canceled,
             &built,
-        ]).expect("Put running");
+        ]));
+        Ok(())
     }
     fn take_running(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<RunningEntry<P>> {
-        let trans = self.conn.transaction()
-            .expect("Start take-running transaction");
+    ) -> Result<Option<RunningEntry<P>>, Box<Error + Send + Sync>> {
+        let trans = try!(self.conn.transaction());
         let sql = r###"
             SELECT pr, pull_commit, merge_commit, message, canceled, built
             FROM running
             WHERE pipeline_id = $1
         "###;
         let entry = {
-            let stmt = trans.prepare(&sql)
-                .expect("Prepare take-running query");
-            let rows = stmt.query(&[&pipeline_id.0])
-                .expect("To take running");
+            let stmt = try!(trans.prepare(&sql));
+            let rows = try!(stmt.query(&[&pipeline_id.0]));
             let rows = rows.iter();
             let mut rows = rows.map(|row| RunningEntry {
                 pr: P::from_str(&row.get::<_, String>(0)[..]).unwrap(),
@@ -347,23 +348,21 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
         let sql = r###"
             DELETE FROM running WHERE pipeline_id = $1
         "###;
-        trans.execute(sql, &[&pipeline_id.0]).expect("Remove running entry");
-        trans.commit().expect("Commit take-running transaction");
-        entry
+        try!(trans.execute(sql, &[&pipeline_id.0]));
+        try!(trans.commit());
+        Ok(entry)
     }
     fn peek_running(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Option<RunningEntry<P>> {
+    ) -> Result<Option<RunningEntry<P>>, Box<Error + Send + Sync>> {
         let sql = r###"
             SELECT pr, pull_commit, merge_commit, message, canceled, built
             FROM running
             WHERE pipeline_id = $1
         "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare peek-running query");
-        let rows = stmt.query(&[&pipeline_id.0]);
-        let rows = rows.expect("Get running query");
+        let stmt = try!(self.conn.prepare(&sql));
+        let rows = try!(stmt.query(&[&pipeline_id.0]));
         let rows = rows.iter();
         let mut rows = rows.map(|row| RunningEntry {
             pr: P::from_str(&row.get::<_, String>(0)[..]).unwrap(),
@@ -376,55 +375,52 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             canceled: row.get(4),
             built: row.get(5),
         });
-        rows.next()
+        Ok(rows.next())
     }
     fn add_pending(
         &mut self,
         pipeline_id: PipelineId,
         entry: PendingEntry<P>,
-    ) {
-        let trans = self.conn.transaction()
-            .expect("Start add-pending transaction");
+    ) -> Result<(), Box<Error + Send + Sync>> {
+        let trans = try!(self.conn.transaction());
         let sql = r###"
             DELETE FROM pending WHERE pipeline_id = $1 AND pr = $2
         "###;
-        trans.execute(sql, &[
+        try!(trans.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(entry.pr.clone()),
-        ]).expect("Remove pending entry");
+        ]));
         let sql = r###"
             INSERT INTO pending (pipeline_id, pr, pull_commit, title, url)
             VALUES ($1, $2, $3, $4, $5)
         "###;
-        trans.execute(sql, &[
+        try!(trans.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(entry.pr.clone()),
             &<P::C as Into<String>>::into(entry.commit.clone()),
             &entry.title,
             &entry.url.as_str(),
-        ]).expect("Add pending entry");
-        trans.commit().expect("Commit add-pending transaction");
+        ]));
+        try!(trans.commit());
+        Ok(())
     }
     fn take_pending_by_pr(
         &mut self,
         pipeline_id: PipelineId,
         pr: &P,
-    ) -> Option<PendingEntry<P>> {
-        let trans = self.conn.transaction()
-            .expect("Start take-pending transaction");
+    ) -> Result<Option<PendingEntry<P>>, Box<Error + Send + Sync>> {
+        let trans = try!(self.conn.transaction());
         let sql = r###"
             SELECT id, pr, pull_commit, title, url
             FROM pending
             WHERE pipeline_id = $1 AND pr = $2
         "###;
         let entry = {
-            let stmt = trans.prepare(&sql)
-                .expect("Prepare take-pending query");
-            let rows = stmt.query(&[
+            let stmt = try!(trans.prepare(&sql));
+            let rows = try!(stmt.query(&[
                 &pipeline_id.0,
                 &<P as Into<String>>::into(pr.clone()),
-            ]);
-            let rows = rows.expect("Get pending entry");
+            ]));
             let rows = rows.iter();
             let mut rows = rows.map(|row| (row.get::<_, i32>(0), PendingEntry {
                 pr: P::from_str(&row.get::<_, String>(1)[..]).unwrap(),
@@ -439,28 +435,26 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             let sql = r###"
                 DELETE FROM pending WHERE id = $1
             "###;
-            trans.execute(sql, &[&entry.0]).expect("Remove pending entry");
-            trans.commit().expect("Commit take-pending transaction");
+            try!(trans.execute(sql, &[&entry.0]));
+            try!(trans.commit());
         }
-        entry.map(|entry| entry.1)
+        Ok(entry.map(|entry| entry.1))
     }
     fn peek_pending_by_pr(
         &mut self,
         pipeline_id: PipelineId,
         pr: &P,
-    ) -> Option<PendingEntry<P>> {
+    ) -> Result<Option<PendingEntry<P>>, Box<Error + Send + Sync>> {
         let sql = r###"
             SELECT pr, pull_commit, title, url
             FROM pending
             WHERE pipeline_id = $1 AND pr = $2
         "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare peek-pending query");
-        let rows = stmt.query(&[
+        let stmt = try!(self.conn.prepare(&sql));
+        let rows = try!(stmt.query(&[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr.clone()),
-        ]);
-        let rows = rows.expect("Get pending entry");
+        ]));
         let rows = rows.iter();
         let mut rows = rows.map(|row| PendingEntry {
             pr: P::from_str(&row.get::<_, String>(0)[..]).unwrap(),
@@ -469,21 +463,19 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             title: row.get(2),
             url: Url::parse(&row.get::<_, String>(3)).unwrap(),
         });
-        rows.next()
+        Ok(rows.next())
     }
     fn list_pending(
         &mut self,
         pipeline_id: PipelineId,
-    ) -> Vec<PendingEntry<P>> {
+    ) -> Result<Vec<PendingEntry<P>>, Box<Error + Send + Sync>> {
         let sql = r###"
             SELECT pr, pull_commit, title, url
             FROM pending
             WHERE pipeline_id = $1
         "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare peek-pending query");
-        let rows = stmt.query(&[&pipeline_id.0]);
-        let rows = rows.expect("Get pending entry");
+        let stmt = try!(self.conn.prepare(&sql));
+        let rows = try!(stmt.query(&[&pipeline_id.0]));
         let rows = rows.iter();
         let rows = rows.map(|row| PendingEntry {
             pr: P::from_str(&row.get::<_, String>(0)[..]).unwrap(),
@@ -493,52 +485,57 @@ impl<'a, P> Db<P> for PostgresTransaction<'a, P>
             url: Url::parse(&row.get::<_, String>(3)).unwrap(),
         });
         let rows: Vec<PendingEntry<P>> = rows.collect();
-        rows
+        Ok(rows)
     }
-    fn cancel_by_pr(&mut self, pipeline_id: PipelineId, pr: &P) {
+    fn cancel_by_pr(
+        &mut self,
+        pipeline_id: PipelineId,
+        pr: &P,
+    ) -> Result<(), Box<Error + Send + Sync>> {
         let sql = r###"
             UPDATE running
             SET canceled = TRUE
             WHERE pipeline_id = $1 AND pr = $2
         "###;
-        self.conn.execute(sql, &[
+        try!(self.conn.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr.clone()),
-        ]).expect("Cancel running PR");
+        ]));
         let sql = r###"
             DELETE FROM queue
             WHERE pipeline_id = $1 AND pr = $2
         "###;
-        self.conn.execute(sql, &[
+        try!(self.conn.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr.clone()),
-        ]).expect("Cancel queue entries");
+        ]));
+        Ok(())
     }
     fn cancel_by_pr_different_commit(
         &mut self,
         pipeline_id: PipelineId,
         pr: &P,
         commit: &P::C,
-    ) -> bool {
+    ) -> Result<bool, Box<Error + Send + Sync>> {
         let sql = r###"
             UPDATE running
             SET canceled = TRUE
             WHERE pipeline_id = $1 AND pr = $2 AND pull_commit <> $3
         "###;
-        let affected_rows_running = self.conn.execute(sql, &[
+        let affected_rows_running = try!(self.conn.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr.clone()),
             &<P::C as Into<String>>::into(commit.clone()),
-        ]).expect("Cancel running PR");
+        ]));
         let sql = r###"
             DELETE FROM queue
             WHERE pipeline_id = $1 AND pr = $2 AND pull_commit <> $3
         "###;
-        let affected_rows_queue = self.conn.execute(sql, &[
+        let affected_rows_queue = try!(self.conn.execute(sql, &[
             &pipeline_id.0,
             &<P as Into<String>>::into(pr.clone()),
             &<P::C as Into<String>>::into(commit.clone()),
-        ]).expect("Cancel queue entries");
-        affected_rows_queue != 0 || affected_rows_running != 0
+        ]));
+        Ok(affected_rows_queue != 0 || affected_rows_running != 0)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,10 @@ impl<'cntx, P, B, U, V> db::Transaction<P>
           B: Ci<P::C> + 'cntx,
           U: Ui<P> + 'cntx,
           V: Vcs<P::C> + 'cntx {
-    fn run<D: Db<P>>(mut self, db: &mut D) -> Result<(), Box<Error + Send + Sync>> {
+    fn run<D: Db<P>>(
+        mut self,
+        db: &mut D
+    ) -> Result<(), Box<Error + Send + Sync>> {
         use std::thread;
         use std::time::Duration;
         use util::{MIN_DELAY_SEC, MAX_DELAY_SEC};

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,12 @@ extern crate toml;
 extern crate url;
 extern crate void;
 
+#[macro_use] mod util;
 mod ci;
 mod config;
 mod db;
 mod pipeline;
 mod ui;
-mod util;
 mod view;
 mod vcs;
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -222,7 +222,8 @@ where P: Pr + 'static,
                 assert_eq!(&pipeline_id, &self.id);
                 let commit = match (
                     commit,
-                    try!(db.peek_pending_by_pr(self.id, &pr)).map(|p| p.commit),
+                    try!(db.peek_pending_by_pr(self.id, &pr))
+                        .map(|p| p.commit),
                 ) {
                     (Some(reviewed_pr), Some(current_pr)) => {
                         if reviewed_pr != current_pr {
@@ -280,7 +281,11 @@ where P: Pr + 'static,
                 pipeline_id, pr, commit, title, url
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if try!(db.cancel_by_pr_different_commit(self.id, &pr, &commit)) {
+                if try!(db.cancel_by_pr_different_commit(
+                    self.id,
+                    &pr,
+                    &commit,
+                )) {
                     self.ui.send_result(
                         self.id,
                         pr.clone(),

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -3,6 +3,7 @@
 use ci;
 use config::PipelineConfig;
 use db::{Db, PendingEntry, QueueEntry, RunningEntry};
+use std::error::Error;
 use std::marker::PhantomData;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
@@ -210,7 +211,7 @@ where P: Pr + 'static,
         &mut self,
         db: &mut D,
         event: Event<P>,
-    ) {
+    ) -> Result<(), Box<Error + Send + Sync>> {
         match event {
             Event::UiEvent(ui::Event::Approved(
                 pipeline_id,
@@ -221,7 +222,7 @@ where P: Pr + 'static,
                 assert_eq!(&pipeline_id, &self.id);
                 let commit = match (
                     commit,
-                    db.peek_pending_by_pr(self.id, &pr).map(|p| p.commit),
+                    try!(db.peek_pending_by_pr(self.id, &pr)).map(|p| p.commit),
                 ) {
                     (Some(reviewed_pr), Some(current_pr)) => {
                         if reviewed_pr != current_pr {
@@ -256,51 +257,51 @@ where P: Pr + 'static,
                         pr.clone(),
                         ui::Status::Approved(commit.clone()),
                     );
-                    db.cancel_by_pr(self.id, &pr);
-                    db.push_queue(self.id, QueueEntry{
+                    try!(db.cancel_by_pr(self.id, &pr));
+                    try!(db.push_queue(self.id, QueueEntry{
                         commit: commit,
                         pr: pr,
                         message: message,
-                    });
+                    }));
                 }
             },
             Event::UiEvent(ui::Event::Opened(
                 pipeline_id, pr, commit, title, url
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                db.add_pending(self.id, PendingEntry{
+                try!(db.add_pending(self.id, PendingEntry{
                     commit: commit,
                     pr: pr,
                     title: title,
                     url: url,
-                });
+                }));
             },
             Event::UiEvent(ui::Event::Changed(
                 pipeline_id, pr, commit, title, url
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if db.cancel_by_pr_different_commit(self.id, &pr, &commit) {
+                if try!(db.cancel_by_pr_different_commit(self.id, &pr, &commit)) {
                     self.ui.send_result(
                         self.id,
                         pr.clone(),
                         ui::Status::Invalidated,
                     );
                 }
-                db.add_pending(self.id, PendingEntry{
+                try!(db.add_pending(self.id, PendingEntry{
                     commit: commit,
                     pr: pr,
                     title: title,
                     url: url,
-                });
+                }));
             },
             Event::UiEvent(ui::Event::Closed(pipeline_id, pr)) => {
                 assert_eq!(&pipeline_id, &self.id);
-                db.take_pending_by_pr(self.id, &pr);
-                db.cancel_by_pr(self.id, &pr);
+                try!(db.take_pending_by_pr(self.id, &pr));
+                try!(db.cancel_by_pr(self.id, &pr));
             },
             Event::UiEvent(ui::Event::Canceled(pipeline_id, pr)) => {
                 assert_eq!(&pipeline_id, &self.id);
-                db.cancel_by_pr(self.id, &pr);
+                try!(db.cancel_by_pr(self.id, &pr));
             },
             Event::VcsEvent(vcs::Event::MergedToStaging(
                 pipeline_id,
@@ -308,7 +309,7 @@ where P: Pr + 'static,
                 merge_commit
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(mut running) = db.take_running(self.id) {
+                if let Some(mut running) = try!(db.take_running(self.id)) {
                     if running.pull_commit != pull_commit {
                         warn!("VCS merged event with wrong commit");
                     } else if running.merge_commit.is_some() {
@@ -331,7 +332,7 @@ where P: Pr + 'static,
                                 merge_commit,
                             ),
                         );
-                        db.put_running(self.id, running);
+                        try!(db.put_running(self.id, running));
                     }
                 } else {
                     warn!("VCS merged event with no queued PR");
@@ -342,7 +343,7 @@ where P: Pr + 'static,
                 pull_commit,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(running) = db.take_running(self.id) {
+                if let Some(running) = try!(db.take_running(self.id)) {
                     if running.pull_commit != pull_commit {
                         warn!("VCS merged event with wrong commit");
                     } else if running.merge_commit.is_some() {
@@ -368,7 +369,7 @@ where P: Pr + 'static,
                 url,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(running) = db.peek_running(self.id) {
+                if let Some(running) = try!(db.peek_running(self.id)) {
                     if let Some(merged_commit) = running.merge_commit {
                         if merged_commit != building_commit {
                             warn!("Building a different commit");
@@ -400,17 +401,17 @@ where P: Pr + 'static,
                 url,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(running) = db.take_running(self.id) {
+                if let Some(running) = try!(db.take_running(self.id)) {
                     if let Some(ref merged_commit) = running.merge_commit {
                         if merged_commit != &built_commit {
                             warn!("Finished building a different commit");
-                            db.put_running(self.id, running.clone());
+                            try!(db.put_running(self.id, running.clone()));
                         } else if running.canceled {
                             // Drop it on the floor. It's canceled.
                         } else if running.built {
                             warn!("Got duplicate BuildFailed event");
                             // Put it back
-                            db.put_running(self.id, running.clone());
+                            try!(db.put_running(self.id, running.clone()));
                         } else {
                             self.ui.send_result(
                                 self.id,
@@ -435,17 +436,17 @@ where P: Pr + 'static,
                 url,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(mut running) = db.take_running(self.id) {
+                if let Some(mut running) = try!(db.take_running(self.id)) {
                     if let Some(ref merged_commit) = running.merge_commit {
                         if merged_commit != &built_commit {
                             warn!("Finished building a different commit");
-                            db.put_running(self.id, running.clone());
+                            try!(db.put_running(self.id, running.clone()));
                         } else if running.canceled {
                             // Canceled; drop on the floor.
                         } else if running.built {
                             warn!("Got duplicate BuildSucceeded event");
                             // Put it back.
-                            db.put_running(self.id, running.clone());
+                            try!(db.put_running(self.id, running.clone()));
                         } else {
                             self.vcs.move_staging_to_master(
                                 self.id,
@@ -462,7 +463,7 @@ where P: Pr + 'static,
                             );
                             // Put it back with it marked as built.
                             running.built = true;
-                            db.put_running(self.id, running.clone());
+                            try!(db.put_running(self.id, running.clone()));
                         }
                     } else {
                         warn!("Finished building a commit that never merged");
@@ -476,7 +477,7 @@ where P: Pr + 'static,
                 merge_commit,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(running) = db.take_running(self.id) {
+                if let Some(running) = try!(db.take_running(self.id)) {
                     if let Some(running_merge_commit) = running.merge_commit {
                         if running_merge_commit != merge_commit {
                             warn!("VCS move event with wrong commit");
@@ -506,7 +507,7 @@ where P: Pr + 'static,
                 merge_commit,
             )) => {
                 assert_eq!(&pipeline_id, &self.id);
-                if let Some(running) = db.take_running(self.id) {
+                if let Some(running) = try!(db.take_running(self.id)) {
                     if let Some(running_merge_commit) = running.merge_commit {
                         if running_merge_commit != merge_commit {
                             warn!("VCS move event with wrong commit");
@@ -532,24 +533,25 @@ where P: Pr + 'static,
                 }
             }
         }
-        if db.peek_running(self.id).is_none() {
-            if let Some(next) = db.pop_queue(self.id) {
+        if try!(db.peek_running(self.id)).is_none() {
+            if let Some(next) = try!(db.pop_queue(self.id)) {
                 self.vcs.merge_to_staging(
                     self.id,
                     next.commit.clone(),
                     next.message.clone(),
                     next.pr.remote(),
                 );
-                db.put_running(self.id, RunningEntry{
+                try!(db.put_running(self.id, RunningEntry{
                     pr: next.pr,
                     message: next.message,
                     pull_commit: next.commit,
                     merge_commit: None,
                     canceled: false,
                     built: false,
-                });
+                }));
             }
         }
+        Ok(())
     }
 }
 

--- a/src/pipeline/test.rs
+++ b/src/pipeline/test.rs
@@ -563,7 +563,7 @@ fn handle_merge_failed_notify_user() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -597,12 +597,12 @@ fn handle_merge_failed_notify_user_merge_next_commit() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "M!".to_owned(),
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -644,7 +644,7 @@ fn handle_merge_succeeded_notify_user_start_ci() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -691,7 +691,7 @@ fn handle_ci_failed_notify_user() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -731,12 +731,12 @@ fn handle_ci_failed_notify_user_next_commit() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "M!".to_owned(),
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -783,7 +783,7 @@ fn handle_ci_started_notify_user() {
         canceled: false,
         message: "MSG!".to_owned(),
         built: false,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -821,7 +821,7 @@ fn handle_ci_succeeded_move_to_master() {
         canceled: false,
         message: "MSG!".to_owned(),
         built: false,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -862,7 +862,7 @@ fn handle_ci_double_succeeded_move_to_master() {
         canceled: false,
         message: "MSG!".to_owned(),
         built: false,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -927,7 +927,7 @@ fn handle_move_failed_notify_user() {
         canceled: false,
         message: "MSG!".to_owned(),
         built: true,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -965,12 +965,12 @@ fn handle_move_failed_notify_user_next_commit() {
         canceled: false,
         message: "MSG!".to_owned(),
         built: true,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "M!".to_owned(),
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -1015,7 +1015,7 @@ fn handle_move_succeeded_notify_user() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: true,
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -1052,12 +1052,12 @@ fn handle_move_succeeded_notify_user_next_commit() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: true,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "M!".to_owned(),
-    });
+    }).unwrap();
     vcs.borrow_mut().staging = Some(MemoryCommit::B);
     handle_event(
         &mut ui,
@@ -1104,7 +1104,7 @@ fn handle_ui_cancel() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -1138,7 +1138,7 @@ fn handle_ui_changed_cancel() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -1175,7 +1175,7 @@ fn handle_ui_changed_no_real_change() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -1212,12 +1212,12 @@ fn handle_ui_changed_cancel_queue() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "MSG!".to_owned(),
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -1255,12 +1255,12 @@ fn handle_ui_changed_no_real_change_queue() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     db.push_queue(PipelineId(0), QueueEntry{
         commit: MemoryCommit::C,
         pr: MemoryPr::B,
         message: "MSG!".to_owned(),
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,
@@ -1302,7 +1302,7 @@ fn handle_ui_closed() {
         message: "MSG!".to_owned(),
         canceled: false,
         built: false,
-    });
+    }).unwrap();
     handle_event(
         &mut ui,
         &mut vcs,

--- a/src/ui/github/cache.rs
+++ b/src/ui/github/cache.rs
@@ -3,7 +3,7 @@
 use db::Builder;
 use rusqlite::{self, Connection};
 use postgres::{Connection as PgConnection, SslMode};
-use postgres::IntoConnectParams;
+use postgres::{ConnectParams, IntoConnectParams};
 use std::convert::AsRef;
 use std::error::Error;
 use std::path::Path;
@@ -26,7 +26,7 @@ pub enum Cache {
 }
 
 impl Cache {
-    pub fn set_teams_with_write<T: Iterator<Item=TeamId>>(
+    pub fn set_teams_with_write<T: Clone + Iterator<Item=TeamId>>(
         &mut self,
         pipeline_id: PipelineId,
         teams: T,
@@ -157,15 +157,17 @@ impl Sqlite {
 }
 
 pub struct Postgres {
-    conn: PgConnection,
+    params: ConnectParams,
 }
 
 impl Postgres {
     fn open<Q: IntoConnectParams>(
         params: Q
     ) -> Result<Self, Box<Error + Send + Sync>> {
-        let conn = try!(PgConnection::connect(params, SslMode::None));
-        try!(conn.batch_execute(r###"
+        let result = Postgres{
+            params: try!(params.into_connect_params()),
+        };
+        try!(try!(result.conn()).batch_execute(r###"
             CREATE TABLE IF NOT EXISTS github_teams_with_write (
                 pipeline_id INTEGER,
                 team_id INTEGER,
@@ -176,81 +178,88 @@ impl Postgres {
                 is_org BOOLEAN
             )
         "###));
-        Ok(Postgres{
-            conn: conn,
-        })
+        Ok(result)
     }
-    fn set_teams_with_write<T: Iterator<Item=TeamId>>(
+    fn conn(&self) -> Result<PgConnection, Box<Error + Send + Sync>> {
+        Ok(try!(PgConnection::connect(self.params.clone(), SslMode::None)))
+    }
+    fn set_teams_with_write<T: Clone + Iterator<Item=TeamId>>(
         &mut self,
         pipeline_id: PipelineId,
         team_ids: T,
     ) {
-        let trans = self.conn
-            .transaction()
-            .expect("Start pop-from-queue transaction");
-        let sql = r###"
-            DELETE FROM github_teams_with_write
-            WHERE pipeline_id = $1
-        "###;
-        trans.execute(sql, &[
-            &pipeline_id.0,
-        ]).expect("to clear all teams");
-        let sql = r###"
-            INSERT INTO github_teams_with_write (pipeline_id, team_id)
-            VALUES ($1, $2)
-            ON CONFLICT DO NOTHING
-        "###;
-        for team_id in team_ids {
-            assert!(team_id.0 != 0);
-            trans.execute(sql, &[
+        retry!{{
+            let conn = retry_unwrap!(self.conn());
+            let trans = retry_unwrap!(conn.transaction());
+            let sql = r###"
+                DELETE FROM github_teams_with_write
+                WHERE pipeline_id = $1
+            "###;
+            retry_unwrap!(trans.execute(sql, &[
                 &pipeline_id.0,
-                &(team_id.0 as i32),
-            ]).expect("to add a team");
-        }
-        trans.commit().expect("Commit pop-from-queue transaction");
+            ]));
+            let sql = r###"
+                INSERT INTO github_teams_with_write (pipeline_id, team_id)
+                VALUES ($1, $2)
+                ON CONFLICT DO NOTHING
+            "###;
+            for team_id in team_ids.clone() {
+                assert!(team_id.0 != 0);
+                retry_unwrap!(trans.execute(sql, &[
+                    &pipeline_id.0,
+                    &(team_id.0 as i32),
+                ]));
+            }
+            retry_unwrap!(trans.commit());
+        }}
     }
     fn teams_with_write(
         &mut self,
         pipeline_id: PipelineId
     ) -> Vec<TeamId> {
-        let sql = r###"
-            SELECT team_id
-            FROM github_teams_with_write
-            WHERE pipeline_id = $1
-        "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare peek-running query");
-        let rows = stmt.query(&[&pipeline_id.0]);
-        let rows = rows.expect("Get running entry");
-        let rows = rows.iter();
-        let rows = rows.map(|row| {
-            TeamId(row.get::<_, i32>(0) as u32)
-        });
-        let ret_val = rows.collect();
-        ret_val
+        retry!{{
+            let sql = r###"
+                SELECT team_id
+                FROM github_teams_with_write
+                WHERE pipeline_id = $1
+            "###;
+            let conn = retry_unwrap!(self.conn());
+            let stmt = retry_unwrap!(conn.prepare(&sql));
+            let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+            let rows = rows.iter();
+            let rows = rows.map(|row| {
+                TeamId(row.get::<_, i32>(0) as u32)
+            });
+            let ret_val = rows.collect();
+            ret_val
+        }}
     }
     fn is_org(&mut self, pipeline_id: PipelineId) -> Option<bool> {
-        let sql = r###"
-            SELECT is_org
-            FROM github_is_org
-            WHERE pipeline_id = $1
-        "###;
-        let stmt = self.conn.prepare(&sql)
-            .expect("Prepare peek-running query");
-        let rows = stmt.query(&[&pipeline_id.0]);
-        let rows = rows.expect("Get is-org");
-        let rows = rows.iter();
-        let mut rows = rows.map(|row| row.get::<_, bool>(0));
-        rows.next()
+        retry!{{
+            let sql = r###"
+                SELECT is_org
+                FROM github_is_org
+                WHERE pipeline_id = $1
+            "###;
+            let conn = retry_unwrap!(self.conn());
+            let stmt = retry_unwrap!(conn.prepare(&sql));
+            let rows = retry_unwrap!(stmt.query(&[&pipeline_id.0]));
+            let rows = rows.iter();
+            let mut rows = rows.map(|row| row.get::<_, bool>(0));
+            rows.next()
+        }}
     }
     fn set_is_org(&mut self, pipeline_id: PipelineId, is_org: bool) {
-        let sql = r###"
-            INSERT INTO github_is_org (pipeline_id, is_org)
-            VALUES ($1, $2)
-            ON CONFLICT (pipeline_id) DO UPDATE SET is_org = $2
-        "###;
-        self.conn.execute(sql, &[
-            &pipeline_id.0, &is_org
-        ]).expect("to set is_org");
+        retry!{{
+            let sql = r###"
+                INSERT INTO github_is_org (pipeline_id, is_org)
+                VALUES ($1, $2)
+                ON CONFLICT (pipeline_id) DO UPDATE SET is_org = $2
+            "###;
+            let conn = retry_unwrap!(self.conn());
+            retry_unwrap!(conn.execute(sql, &[
+                &pipeline_id.0, &is_org
+            ]));
+        }}
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,3 +5,6 @@ pub mod github_headers;
 
 pub const USER_AGENT: &'static str =
     "aelita/0.1 (https://github.com/AelitaBot/aelita)";
+
+pub const MIN_DELAY_SEC: u64 = 1;
+pub const MAX_DELAY_SEC: u64 = 60*2;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,3 +8,31 @@ pub const USER_AGENT: &'static str =
 
 pub const MIN_DELAY_SEC: u64 = 1;
 pub const MAX_DELAY_SEC: u64 = 60*2;
+
+macro_rules! retry {
+    ($e: expr) => {
+        use std::time::Duration;
+        use util::{MIN_DELAY_SEC, MAX_DELAY_SEC};
+        let mut delay = Duration::new(MIN_DELAY_SEC / 2, 0);
+        let max = Duration::new(MAX_DELAY_SEC, 0);
+        loop {
+            delay = delay * 2;
+            if delay > max {
+                panic!("retry loop exceeded maximum delay");
+            }
+            return $e;
+        }
+    }
+}
+
+macro_rules! retry_unwrap {
+    ($e: expr) => {
+        match $e {
+            Ok(x) => x,
+            Err(e) => {
+                warn!("Retrying? {:?}", e);
+                continue;
+            }
+        }
+    }
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -285,11 +285,11 @@ impl<'a, P: Pr> Thread<'a, P>
                             th { : "Opened" }
                         }
                         tbody {
-                            @ for &(ref n, pid) in &pipelines { |t| {
+                            @ for &(ref n, pid) in &pipelines { |t| retry!{{
                                 let n = &**n;
-                                let opened = try!(self.db.list_pending(pid).wc()).len();
-                                let queue = try!(self.db.list_queue(pid).wc()).len();
-                                let running = try!(self.db.peek_running(pid).wc())
+                                let opened = retry_unwrap!(self.db.list_pending(pid).wc()).len();
+                                let queue = retry_unwrap!(self.db.list_queue(pid).wc()).len();
+                                let running = retry_unwrap!(self.db.peek_running(pid).wc())
                                     .is_some();
                                 let running = if running { 1 } else { 0 };
                                 let review = opened - queue - running;
@@ -303,9 +303,8 @@ impl<'a, P: Pr> Thread<'a, P>
                                         td { : review }
                                         td { : opened }
                                     }
-                                };
-                                Ok::<(), Box<Error>>(())
-                            }}
+                                }
+                            }}}
                             @ if pipelines.is_empty() {
                                 td(colspan=5) {
                                     : "No configured repositories"

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -287,10 +287,15 @@ impl<'a, P: Pr> Thread<'a, P>
                         tbody {
                             @ for &(ref n, pid) in &pipelines { |t| retry!{{
                                 let n = &**n;
-                                let opened = retry_unwrap!(self.db.list_pending(pid).wc()).len();
-                                let queue = retry_unwrap!(self.db.list_queue(pid).wc()).len();
-                                let running = retry_unwrap!(self.db.peek_running(pid).wc())
-                                    .is_some();
+                                let opened = retry_unwrap!(
+                                    self.db.list_pending(pid).wc()
+                                ).len();
+                                let queue = retry_unwrap!(
+                                    self.db.list_queue(pid).wc()
+                                ).len();
+                                let running = retry_unwrap!(
+                                    self.db.peek_running(pid).wc()
+                                ).is_some();
                                 let running = if running { 1 } else { 0 };
                                 let review = opened - queue - running;
                                 t << html!{


### PR DESCRIPTION
Between all these commits, it changes the way database connections are treated:

* They will not be held forever. Every new transaction opens a connection, and it's closed after the transaction ends. This works around the fact that [the kubernetes load balancer will kill connections after a timeout](http://kubernetes.io/docs/admin/kube-proxy/), as well as the fact that Postgres will keep a process open until it gets an active disconnect. (In other words, we were leaking Postgres processes).
* We will also intelligently retry our database accesses, which should prevent us from dying when a Postgres instance gets migrated from one node to another.