### PR TITLE
Improve view performance by not constantly reconnecting

### DIFF
--- a/infra/aelita.yaml
+++ b/infra/aelita.yaml
@@ -80,7 +80,7 @@ spec:
               path: /
               port: 8000
             initialDelaySeconds: 5
-            timeoutSeconds: 1
+            timeoutSeconds: 2
 
 ---
 
@@ -141,7 +141,7 @@ spec:
             tcpSocket:
               port: 8000
             initialDelaySeconds: 5
-            timeoutSeconds: 1
+            timeoutSeconds: 2
 
 ---
 
@@ -321,7 +321,7 @@ spec:
               path: /healthz
               port: 80
             initialDelaySeconds: 5
-            timeoutSeconds: 1
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
               path: /
@@ -330,7 +330,7 @@ spec:
                 - name: Host
                   value: "aelitabot.xyz"
             initialDelaySeconds: 30
-            timeoutSeconds: 2
+            timeoutSeconds: 4
 
 ---
 
@@ -387,5 +387,5 @@ spec:
               path: /healthz
               port: 8080
             initialDelaySeconds: 5
-            timeoutSeconds: 1
+            timeoutSeconds: 2
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -56,7 +56,7 @@ impl<P: Pr> Db<P> for DbBox<P>
     fn transaction<T: Transaction<P>>(
         &mut self,
         t: T,
-    ) -> Result<(), Box<Error + Send + Sync>> {
+    ) -> Result<T::Return, Box<Error + Send + Sync>> {
         match *self {
             DbBox::Sqlite(ref mut d) => d.transaction(t),
             DbBox::Postgres(ref mut d) => d.transaction(t),
@@ -198,7 +198,7 @@ pub trait Db<P: Pr>: Sized {
     fn transaction<T: Transaction<P>>(
         &mut self,
         t: T,
-    ) -> Result<(), Box<Error + Send + Sync>> {
+    ) -> Result<T::Return, Box<Error + Send + Sync>> {
         t.run(self)
     }
     fn push_queue(
@@ -263,7 +263,11 @@ pub trait Db<P: Pr>: Sized {
 }
 
 pub trait Transaction<P: Pr> {
-    fn run<D: Db<P>>(self, &mut D) -> Result<(), Box<Error + Send + Sync>>;
+    type Return;
+    fn run<D: Db<P>>(
+        self,
+        &mut D,
+    ) -> Result<Self::Return, Box<Error + Send + Sync>>;
 }
 
 /// An item not yet in the build queue

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -67,14 +67,14 @@ impl<P> Db<P> for PostgresDb<P>
     fn transaction<T: db::Transaction<P>>(
         &mut self,
         t: T,
-    ) -> Result<(), Box<Error + Send + Sync>> {
+    ) -> Result<T::Return, Box<Error + Send + Sync>> {
         let conn = try!(self.conn());
         let mut transaction = PostgresTransaction::new(
             try!(conn.transaction())
         );
-        try!(t.run(&mut transaction));
+        let return_ = try!(t.run(&mut transaction));
         try!(transaction.conn.commit());
-        Ok(())
+        Ok(return_)
     }
     fn push_queue(
         &mut self,

--- a/src/db/sqlite.rs
+++ b/src/db/sqlite.rs
@@ -65,13 +65,13 @@ impl<P> Db<P> for SqliteDb<P>
     fn transaction<T: db::Transaction<P>>(
         &mut self,
         t: T,
-    ) -> Result<(), Box<Error + Send + Sync>> {
+    ) -> Result<T::Return, Box<Error + Send + Sync>> {
         let mut transaction = SqliteTransaction::new(
             try!(self.conn.transaction())
         );
-        try!(t.run(&mut transaction));
+        let return_ = try!(t.run(&mut transaction));
         try!(transaction.conn.commit());
-        Ok(())
+        Ok(return_)
     }
     fn push_queue(
         &mut self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ impl<'cntx, P, B, U, V> db::Transaction<P>
           B: Ci<P::C> + 'cntx,
           U: Ui<P> + 'cntx,
           V: Vcs<P::C> + 'cntx {
+    type Return = ();
     fn run<D: Db<P>>(
         mut self,
         db: &mut D


### PR DESCRIPTION
This is not a perfect fix for the home page (it cuts the connections down by exactly 1/3), but it does bring the details pages down to one connection.